### PR TITLE
Initial refactoring for Chunk sending (Kraken -> Harpoon)

### DIFF
--- a/scripts/buildDev.sh
+++ b/scripts/buildDev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+mkdir -p  build
+PATH=/usr/local/probe/bin:$PATH
+rm -f  CMakeCache.txt
+cd 3rdparty
+unzip -u gtest-1.7.0.zip
+cd ../build
+/usr/local/probe/bin/cmake -DCMAKE_CXX_COMPILER_ARG1:STRING=' -fPIC -Ofast -m64 -Wl,-rpath,. -Wl,-rpath -Wl,/usr/local/probe/lib -Wl,-rpath -Wl,/usr/local/probe/lib64 ' -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_SHARED_LIBS:BOOL=ON -DCMAKE_CXX_COMPILER=/usr/local/probe/bin/g++ ..
+make -j8
+sudo ./UnitTestRunner

--- a/src/Kraken.cpp
+++ b/src/Kraken.cpp
@@ -133,7 +133,7 @@ Kraken::Battling Kraken::NextChunkId(){
 * @param dataToSend
 * @return status of the send operation
 */
-Kraken::Battling Kraken::SendTidalWave(const std::vector<uint8_t>& dataToSend){
+Kraken::Battling Kraken::SendTidalWave(const Kraken::Chunks& dataToSend){
    size_t size = dataToSend.size();
    if(size == 0){
       return Kraken::Battling::CONTINUE;   

--- a/src/Kraken.h
+++ b/src/Kraken.h
@@ -30,7 +30,6 @@ public:
 
    enum class Spear : std::int8_t { MISS = -1, IMPALED = 0 };
    enum class Battling : std::int8_t { TIMEOUT = -2, INTERRUPT = -1, CONTINUE = 0 };
-   enum class Status : std::int8_t {BLEEDING=1, DONE=2, ERROR_MAYHEM=3, THE_END=4};
    typedef std::vector<uint8_t> Chunks;
 
 
@@ -43,7 +42,7 @@ public:
    Battling SendTidalWave(const Kraken::Chunks& data);
    virtual ~Kraken();
 
-   
+
     
 protected:
    

--- a/src/Kraken.h
+++ b/src/Kraken.h
@@ -30,6 +30,9 @@ public:
 
    enum class Spear : std::int8_t { MISS = -1, IMPALED = 0 };
    enum class Battling : std::int8_t { TIMEOUT = -2, INTERRUPT = -1, CONTINUE = 0 };
+   enum class Status : std::int8_t {BLEEDING=1, DONE=2, ERROR_MAYHEM=3, THE_END=4};
+   typedef std::vector<uint8_t> Chunks;
+
 
    Kraken();
    Spear SetLocation(const std::string& location);
@@ -37,10 +40,13 @@ public:
    void ChangeDefaultMaxChunkSizeInBytes(const size_t bytes);
    size_t MaxChunkSizeInBytes();
    Battling FinalBreach();
-   Battling SendTidalWave(const std::vector<uint8_t>& data);
+   Battling SendTidalWave(const Kraken::Chunks& data);
    virtual ~Kraken();
+
+   
     
 protected:
+   
    Battling SendRawData(const uint8_t*, int size);
    Battling PollTimeout(int timeoutMs);
    Battling NextChunkId(); 

--- a/src/Kraken.h
+++ b/src/Kraken.h
@@ -39,7 +39,7 @@ public:
    void ChangeDefaultMaxChunkSizeInBytes(const size_t bytes);
    size_t MaxChunkSizeInBytes();
    Battling FinalBreach();
-   Battling SendTidalWave(const Kraken::Chunks& data);
+   Battling SendTidalWave(const Chunks& data);
    virtual ~Kraken();
 
 

--- a/src/KrakenBattle.cpp
+++ b/src/KrakenBattle.cpp
@@ -29,7 +29,7 @@ namespace KrakenBattle {
    * @return merged data uuid<SendType>optional:data/optional:error_msg
    */
    Kraken::Chunks  MergeData(const std::string& uuid, const KrakenBattle::SendType& type, const Kraken::Chunks& data, const std::string& error_msg) {
-      const std::string sendType = SendTypeToString(type);
+      const std::string sendType = EnumToString(type);
       const std::string& uuidToSend = (SendType::End == type ? emptyUUID : uuid);
       std::vector<uint8_t> merged;
       merged.reserve(uuidToSend.size() + sendType.size() + data.size() + error_msg.size());
@@ -113,13 +113,13 @@ namespace KrakenBattle {
       auto sendingResult = SendChunks(kraken, uuid, sendState, chunk, error);
       bool result = (Kraken::Battling::CONTINUE == sendingResult);
       LOG_IF(WARNING, (!result)) << "Failed to send 'SendTidalWave'" << ", uuid: " << uuid
-                                 << ", type: " << KrakenBattle::SendTypeToString(sendState);
+                                 << ", type: " << KrakenBattle::EnumToString(sendState);
 
       if (SendType::End == sendState) {
          sendingResult = kraken->FinalBreach();
          result = (Kraken::Battling::CONTINUE == sendingResult);
          LOG_IF(WARNING, (!result)) << "Failed to send 'FinalBreach'" << ", uuid: " << uuid
-                                    << ", type: " << KrakenBattle::SendTypeToString(sendState);
+                                    << ", type: " << KrakenBattle::EnumToString(sendState);
       }
 
       auto status = KrakenBattle::ProgressType::Stop;
@@ -132,13 +132,24 @@ namespace KrakenBattle {
 
 
 
-   std::string SendTypeToString(const KrakenBattle::SendType& type) {
+   std::string EnumToString(const KrakenBattle::SendType& type) {
       std::string textType = "<ERROR>";
       switch (type) {
          case SendType::Data : textType = "<DATA>"; break;
          case SendType::Done : textType = "<DONE>"; break;
          case SendType::Error : textType = "<ERROR>"; break;
          case SendType::End : textType = "<END>"; break;
+         default:
+            LOG(FATAL) << "Unknown Send::Type: " << static_cast<int>(type);
+      }
+      return textType;
+   }
+
+      std::string EnumToString(const KrakenBattle::ProgressType& type) {
+      std::string textType = "<ERROR>";
+      switch (type) {
+         case ProgressType::Stop : textType = "ProgressType::Stop"; break;
+         case ProgressType::Continue : textType = "ProgressType::Continue"; break;
          default:
             LOG(FATAL) << "Unknown Send::Type: " << static_cast<int>(type);
       }

--- a/src/KrakenBattle.cpp
+++ b/src/KrakenBattle.cpp
@@ -100,7 +100,7 @@ namespace KrakenBattle {
 
 
    /**
-   * Forward  chunks to the client. This will be repeatedly called until an error
+   * Forward  chunks to the client. This can be repeatedly called until an error
    * occurrs (interrupt, timeout) or all is transmitted
    * @param kraken to send the harpoon/client
    * @param uuid to for unique identification

--- a/src/KrakenBattle.cpp
+++ b/src/KrakenBattle.cpp
@@ -21,7 +21,7 @@ namespace KrakenBattle {
 
    /**
    * formats the data to send to the Harpoon according to the specification for
-   *  @ref file and pcap sending
+   * data transfers
    * @param uuid
    * @param type one of Data, Done, Error, End
    * @param data to send (optional, used for SendType::Data)
@@ -77,7 +77,7 @@ namespace KrakenBattle {
          CHECK(toSend.size() == kSplitSize);
          result = kraken->SendTidalWave(toSend);
 
-         for (size_t i = kSplitSize; i < kTotalSize; i += kSplitSizeAdjusted) {
+         for (size_t i = kSplitSize; i <= kTotalSize; i += kSplitSizeAdjusted) {
             if (result != Kraken::Battling::CONTINUE) {
                LOG(WARNING) << "Sending UUID: " << uuid << ", #split break: " << i << ", kTotalSize: " << kTotalSize
                             << ", kSplitSizeAdjusted: " << kSplitSizeAdjusted << ", result: " << static_cast<int>(result);
@@ -145,7 +145,7 @@ namespace KrakenBattle {
       return textType;
    }
 
-      std::string EnumToString(const KrakenBattle::ProgressType& type) {
+   std::string EnumToString(const KrakenBattle::ProgressType& type) {
       std::string textType = "<ERROR>";
       switch (type) {
          case ProgressType::Stop : textType = "ProgressType::Stop"; break;

--- a/src/KrakenBattle.cpp
+++ b/src/KrakenBattle.cpp
@@ -1,0 +1,147 @@
+/*
+ * File:   KrakenBattle.cpp
+ * Author: Kjell Hedstrom
+ *
+ * Created on November 24, 2015
+ */
+
+#include "KrakenBattle.h"
+#include <algorithm>
+#include <iterator>
+#include <g3log/g3log.hpp>
+
+namespace {
+   const std::string emptyUUID = {"00000000-0000-0000-0000-000000000000"};
+   const std::vector<uint8_t> emptyData = {};
+}
+
+
+
+namespace KrakenBattle {
+
+   /**
+   * formats the data to send to the Harpoon according to the specification for
+   *  @ref file and pcap sending
+   * @param uuid
+   * @param type one of Data, Done, Error, End
+   * @param data to send (optional, used for SendType::Data)
+   * @param error message (optional, used for SendType::Error)
+   * @return merged data uuid<SendType>optional:data/optional:error_msg
+   */
+   Kraken::Chunks  MergeData(const std::string& uuid, const KrakenBattle::SendType& type, const Kraken::Chunks& data, const std::string& error_msg) {
+      const std::string sendType = SendTypeToString(type);
+      const std::string& uuidToSend = (SendType::End == type ? emptyUUID : uuid);
+      std::vector<uint8_t> merged;
+      merged.reserve(uuidToSend.size() + sendType.size() + data.size() + error_msg.size());
+      // uuid, type, possible:data, possible:error
+      std::copy(uuidToSend.begin(), uuidToSend.end(), std::back_inserter(merged));
+      std::copy(sendType.begin(), sendType.end(), std::back_inserter(merged));
+
+      if (SendType::Data == type) {
+         std::copy(data.begin(), data.end(), std::back_inserter(merged));
+      } else if (SendType::Error == type) {
+         std::copy(error_msg.begin(), error_msg.end(), std::back_inserter(merged));
+      }
+      return merged;
+   }
+
+
+   /**
+   *  Send  Chunks over Kraken to a Harpoon
+   *  If chunks to send is more than the @ref Kraken::MaxChunkSizeInBytes() then
+   *  it will split up the sending into several separate sends (@ref Kraken::SendTidalWave)
+   * @param kraken to send over
+   * @param uuid
+   * @param sendState
+   * @param chunk to send (optional content, for SendType::Data)
+   * @param error to send (optional content, for SendType::Error)
+   */
+   Kraken::Battling SendChunks(Kraken* kraken, const std::string& uuid, const KrakenBattle::SendType& sendState, const Kraken::Chunks& chunk, const std::string& error) {
+      const size_t kSplitSize = kraken->MaxChunkSizeInBytes();
+      const auto kTotalToSend = MergeData(uuid, sendState, chunk, error);
+      const size_t kTotalSize = kTotalToSend.size();
+      const Kraken::Chunks kHeader = MergeData(uuid, sendState, {}, {}); // {}: ignored
+      const size_t kSplitSizeAdjusted = kSplitSize - kHeader.size();
+      CHECK(kSplitSize > kHeader.size());
+
+      auto result = Kraken::Battling::CONTINUE;
+
+      if (kTotalSize <= kSplitSize) {
+         result = kraken->SendTidalWave(kTotalToSend);
+      } else {
+
+         std::vector<uint8_t> toSend;
+         toSend.reserve(kSplitSize);
+         toSend.assign(kTotalToSend.begin(), kTotalToSend.begin() + kSplitSize);
+
+         CHECK(toSend.size() == kSplitSize);
+         result = kraken->SendTidalWave(toSend);
+
+         for (size_t i = kSplitSize; i < kTotalSize; i += kSplitSizeAdjusted) {
+            if (result != Kraken::Battling::CONTINUE) {
+               LOG(WARNING) << "Sending UUID: " << uuid << ", #split break: " << i << ", kTotalSize: " << kTotalSize
+                            << ", kSplitSizeAdjusted: " << kSplitSizeAdjusted << ", result: " << static_cast<int>(result);
+               break;
+            }
+
+            toSend.assign(kHeader.begin(), kHeader.end());
+            const size_t kLeftSize = kTotalSize - i;
+            const size_t kChunkSize = std::min(kLeftSize, kSplitSizeAdjusted);
+            std::copy(kTotalToSend.begin() + i,
+                      kTotalToSend.begin() + i + kChunkSize,
+                      std::back_inserter(toSend));
+            LOG(INFO) << "Sending UUID: " << uuid << ", #split: " << i << ", toSend size: " << toSend.size();
+            result = kraken->SendTidalWave(toSend);
+         }
+      }
+      return result;
+   }
+
+
+
+   /**
+   * Forward  chunks to the client. This will be repeatedly called until an error
+   * occurrs (interrupt, timeout) or all is transmitted
+   * @param kraken to send the harpoon/client
+   * @param uuid to for unique identification
+   * @param chunk to send to the client should have valid data on SendState::Data
+   * @param sendState (End, Done, Data, Error)
+   * @param error should have meaningful content on  SendState::Error
+   */
+   KrakenBattle::ProgressType  ForwardChunksToClient(Kraken* kraken, const std::string& uuid, const Kraken::Chunks& chunk,
+         const KrakenBattle::SendType& sendState, const std::string& error) {
+      auto sendingResult = SendChunks(kraken, uuid, sendState, chunk, error);
+      bool result = (Kraken::Battling::CONTINUE == sendingResult);
+      LOG_IF(WARNING, (!result)) << "Failed to send 'SendTidalWave'" << ", uuid: " << uuid
+                                 << ", type: " << KrakenBattle::SendTypeToString(sendState);
+
+      if (SendType::End == sendState) {
+         sendingResult = kraken->FinalBreach();
+         result = (Kraken::Battling::CONTINUE == sendingResult);
+         LOG_IF(WARNING, (!result)) << "Failed to send 'FinalBreach'" << ", uuid: " << uuid
+                                    << ", type: " << KrakenBattle::SendTypeToString(sendState);
+      }
+
+      auto status = KrakenBattle::ProgressType::Stop;
+      if (result) {
+         status = KrakenBattle::ProgressType::Continue;
+      }
+      return status;
+   }
+
+
+
+
+   std::string SendTypeToString(const KrakenBattle::SendType& type) {
+      std::string textType = "<ERROR>";
+      switch (type) {
+         case SendType::Data : textType = "<DATA>"; break;
+         case SendType::Done : textType = "<DONE>"; break;
+         case SendType::Error : textType = "<ERROR>"; break;
+         case SendType::End : textType = "<END>"; break;
+         default:
+            LOG(FATAL) << "Unknown Send::Type: " << static_cast<int>(type);
+      }
+      return textType;
+   }
+} // namespace KrakenBattle

--- a/src/KrakenBattle.cpp
+++ b/src/KrakenBattle.cpp
@@ -27,6 +27,8 @@ namespace KrakenBattle {
    * @param data to send (optional, used for SendType::Data)
    * @param error message (optional, used for SendType::Error)
    * @return merged data uuid<SendType>optional:data/optional:error_msg
+   *
+   * Ref: KrakenBattle.h for detailed information regarding the sending
    */
    Kraken::Chunks  MergeData(const std::string& uuid, const KrakenBattle::SendType& type, const Kraken::Chunks& data, const std::string& error_msg) {
       const std::string sendType = EnumToString(type);
@@ -55,6 +57,8 @@ namespace KrakenBattle {
    * @param sendState
    * @param chunk to send (optional content, for SendType::Data)
    * @param error to send (optional content, for SendType::Error)
+   *
+   * Ref: KrakenBattle.h for detailed information regarding the sending
    */
    Kraken::Battling SendChunks(Kraken* kraken, const std::string& uuid, const KrakenBattle::SendType& sendState, const Kraken::Chunks& chunk, const std::string& error) {
       const size_t kSplitSize = kraken->MaxChunkSizeInBytes();
@@ -107,6 +111,8 @@ namespace KrakenBattle {
    * @param chunk to send to the client should have valid data on SendState::Data
    * @param sendState (End, Done, Data, Error)
    * @param error should have meaningful content on  SendState::Error
+   *
+   * Ref: KrakenBattle.h for detailed information regarding the sending
    */
    KrakenBattle::ProgressType  ForwardChunksToClient(Kraken* kraken, const std::string& uuid, const Kraken::Chunks& chunk,
          const KrakenBattle::SendType& sendState, const std::string& error) {

--- a/src/KrakenBattle.h
+++ b/src/KrakenBattle.h
@@ -34,6 +34,7 @@ namespace KrakenBattle {
 
    std::vector<uint8_t>  MergeData(const std::string& uuid, const KrakenBattle::SendType& type, const Kraken::Chunks& optional_data, const std::string& optional_error_msg);
    KrakenBattle::ProgressType  SendChunks(Kraken* kraken, const std::string& uuid, const Kraken::Chunks& chunk, const KrakenBattle::SendType& type, const std::string& error);
-   KrakenBattle::ProgressType  ForwardPCapChunksToClient(Kraken* kraken, const std::string& uuid,const Kraken::Chunks& chunk, const KrakenBattle::SendType& sendState, const std::string& error);
-   std::string SendTypeToString(const KrakenBattle::SendType& type);
+   KrakenBattle::ProgressType  ForwardChunksToClient(Kraken* kraken, const std::string& uuid,const Kraken::Chunks& chunk, const KrakenBattle::SendType& sendState, const std::string& error);
+   std::string EnumToString(const KrakenBattle::SendType& type);
+   std::string EnumToString(const KrakenBattle::ProgressType& type);
 } // KrakenBattle

--- a/src/KrakenBattle.h
+++ b/src/KrakenBattle.h
@@ -1,0 +1,39 @@
+/*
+ * File:   KrakenBattle.h
+ * Author: Kjell Hedstrom
+ *
+ * Created on November 24, 2015
+ */
+
+ #include "Kraken.h"
+#include <vector>
+#include <string>
+
+
+#pragma once
+
+namespace KrakenBattle {
+   /**
+   * Collection of static functions for forwarding data from Kraken to Harpoon receiver
+   * (the www-UI)
+   * Below the following format is used
+   * uuid:       734a83c7-9435-4605-b1f9-4724c81faf21  (random uuid)
+   * empty_uuid: 00000000-0000-0000-0000-000000000000
+   * <DATA>, <END>, <ERROR>: Just like it seems, strings that look exactly like that
+   * data: pcap chunks, raw bytes
+   * error: error message, a string
+   *
+   * The data format is as follows
+   * uuid<DATA>data: continously sending pcap chunks
+   * uuid<ERROR>error: stop sending for one UUID, reason for error is given
+   * uuid<DONE>: done with sending for one UUID, completed without error
+   * empty_uuid<END>: done with sending for ALL UUIDs.
+   */
+   enum class SendType {Data, Done, Error, End};
+   enum class ProgressType{Continue, Stop};
+
+   std::vector<uint8_t>  MergeData(const std::string& uuid, const KrakenBattle::SendType& type, const Kraken::Chunks& optional_data, const std::string& optional_error_msg);
+   KrakenBattle::ProgressType  SendChunks(Kraken* kraken, const std::string& uuid, const Kraken::Chunks& chunk, const KrakenBattle::SendType& type, const std::string& error);
+   KrakenBattle::ProgressType  ForwardPCapChunksToClient(Kraken* kraken, const std::string& uuid,const Kraken::Chunks& chunk, const KrakenBattle::SendType& sendState, const std::string& error);
+   std::string SendTypeToString(const KrakenBattle::SendType& type);
+} // KrakenBattle

--- a/src/KrakenBattle.h
+++ b/src/KrakenBattle.h
@@ -28,6 +28,20 @@ namespace KrakenBattle {
    * uuid<ERROR>error: stop sending for one UUID, reason for error is given
    * uuid<DONE>: done with sending for one UUID, completed without error
    * empty_uuid<END>: done with sending for ALL UUIDs.
+   * 
+   *
+   * 
+   * Detailed explanation
+   * Harpoon Kraken enables data streaming from a server to a client. ( pub:sub :: 1:1 communication).
+   * Kraken: Server that sends the data
+   * =======
+   * SendTidalWave() : Send a data chunk to the client (harpoon). Blocks until there is space available in the queue. Returns TIMEOUT, INTERRUPT, CONTINUE status to indicate the status of the underlying queue.
+   * FinalBreach() : Call to client (harpoon) to indicate the end of a stream.
+   * 
+   * Harpoon: Client that receives the data
+   * =========
+   * Aim() : Set location of the queue (tcp)
+   * Heave() : Request data and wait for the data to be returned. Returns TIMEOUT, INTERRUPT, VICTORIOUS, CONTINUE to indicate status of the stream. VICTORIOUS means the stream has completed.
    */
    enum class SendType {Data, Done, Error, End};
    enum class ProgressType{Continue, Stop};

--- a/test/KrakenBattleTest.cpp
+++ b/test/KrakenBattleTest.cpp
@@ -1,0 +1,65 @@
+/*
+ * File:   KrakenBattleTest.cpp
+ * Author: Kjell Hedstrom
+ *
+ * Created on February 9, 2015
+ */
+
+
+#include "KrakenBattleTest.h"
+#include "Kraken.h"
+#include "KrakenBattle.h"
+#include "Harpoon.h"
+
+
+namespace {
+const std::string gUuid =  "734a83c7-9435-4605-b1f9-4724c81faf21";
+const std::string gEmptyUuid = "00000000-0000-0000-0000-000000000000";
+const Kraken::Chunks gEmptyData = {};
+const Kraken::Chunks gData = {1, 2, 128, 'k', 'j', '2', '1'};
+
+std::string vectorToString(const std::vector<uint8_t>& vec) {
+   std::string data;
+   std::copy(vec.begin(), vec.end(), std::back_inserter(data));
+   return data;
+}
+}
+
+
+TEST_F(KrakenBattleTest, MergeDataTypes_ErrorType) {
+   auto failed = MergeData("123", KrakenBattle::SendType::Error, gEmptyData, "bad stuff");
+   std::vector<uint8_t> expected {'1', '2', '3', '<', 'E', 'R', 'R', 'O', 'R', '>', 'b', 'a', 'd', ' ', 's', 't', 'u', 'f', 'f'};
+
+   EXPECT_TRUE((failed == expected)) << "\nfailed: [" << vectorToString(failed) << "]\nexpected: [" << vectorToString(expected) << "]";
+}
+
+TEST_F(KrakenBattleTest, MergeDataTypes_DataType) {
+   auto send = MergeData("321", KrakenBattle::SendType::Data, gData, "ignored");
+   std::vector<uint8_t> expected {'3', '2', '1', '<', 'D', 'A', 'T', 'A', '>', 1, 2, 128, 'k', 'j', '2', '1'};
+
+   EXPECT_TRUE((send == expected)) << "\nfailed: [" << vectorToString(send) << "]\nexpected: [" << vectorToString(expected) << "]";
+}
+
+TEST_F(KrakenBattleTest, MergeDataTypes_DoneType) {
+   auto send = MergeData(gUuid, KrakenBattle::SendType::Done, gData, "ignored");
+   std::string sendStatus = "<DONE>";
+
+   std::vector<uint8_t> expected;
+   std::copy(gUuid.begin(), gUuid.end(), std::back_inserter(expected));
+   std::copy(sendStatus.begin(), sendStatus.end(), std::back_inserter(expected));
+
+
+   EXPECT_TRUE((send == expected)) << "\nfailed: [" << vectorToString(send) << "]\nexpected: [" << vectorToString(expected) << "]";
+}
+
+
+TEST_F(KrakenBattleTest, MergeDataTypes_EndType) {
+   auto send = MergeData("ignored_uuid", KrakenBattle::SendType::End, gData, "ignored");
+   std::string sendStatus = "<END>";
+
+   std::vector<uint8_t> expected;
+   std::copy(gEmptyUuid.begin(), gEmptyUuid.end(), std::back_inserter(expected));
+   std::copy(sendStatus.begin(), sendStatus.end(), std::back_inserter(expected));
+
+   EXPECT_TRUE((send == expected)) << "\nfailed: [" << vectorToString(send) << "]\nexpected: [" << vectorToString(expected) << "]";
+}

--- a/test/KrakenBattleTest.cpp
+++ b/test/KrakenBattleTest.cpp
@@ -13,16 +13,16 @@
 
 
 namespace {
-const std::string gUuid =  "734a83c7-9435-4605-b1f9-4724c81faf21";
-const std::string gEmptyUuid = "00000000-0000-0000-0000-000000000000";
-const Kraken::Chunks gEmptyData = {};
-const Kraken::Chunks gData = {1, 2, 128, 'k', 'j', '2', '1'};
+   const std::string gUuid =  "734a83c7-9435-4605-b1f9-4724c81faf21";
+   const std::string gEmptyUuid = "00000000-0000-0000-0000-000000000000";
+   const Kraken::Chunks gEmptyData = {};
+   const Kraken::Chunks gData = {1, 2, 128, 'k', 'j', '2', '1'};
 
-std::string vectorToString(const std::vector<uint8_t>& vec) {
-   std::string data;
-   std::copy(vec.begin(), vec.end(), std::back_inserter(data));
-   return data;
-}
+   std::string vectorToString(const std::vector<uint8_t>& vec) {
+      std::string data;
+      std::copy(vec.begin(), vec.end(), std::back_inserter(data));
+      return data;
+   }
 }
 
 
@@ -63,3 +63,5 @@ TEST_F(KrakenBattleTest, MergeDataTypes_EndType) {
 
    EXPECT_TRUE((send == expected)) << "\nfailed: [" << vectorToString(send) << "]\nexpected: [" << vectorToString(expected) << "]";
 }
+
+

--- a/test/KrakenBattleTest.h
+++ b/test/KrakenBattleTest.h
@@ -1,0 +1,36 @@
+/*
+ * File:   KrakenBattleTest.h
+ * Author: Kjell Hedstrom
+ *
+ * Created on November 24, 2015
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <string>
+#include <cstdlib>
+
+class KrakenBattleTest : public ::testing::Test {
+public:
+   KrakenBattleTest() :
+      mTestDirectory("/tmp/TestOfKrakenBattleTest"),
+      mCreateTestDirectory("mkdir -p " + mTestDirectory),
+      mTearDownTestDirectory("rm -rf " + mTestDirectory) {}
+
+   virtual ~KrakenBattleTest() = default;
+
+protected:
+   virtual void SetUp() {
+      system(mTearDownTestDirectory.c_str());
+      EXPECT_EQ(0, system(mCreateTestDirectory.c_str()));
+   }
+
+   virtual void TearDown() {
+      EXPECT_EQ(0, system(mTearDownTestDirectory.c_str()));
+   }
+
+   std::string mTestDirectory;
+   std::string mCreateTestDirectory;
+   std::string mTearDownTestDirectory;
+};

--- a/test/KrakenIntegrationTest.cpp
+++ b/test/KrakenIntegrationTest.cpp
@@ -1,0 +1,178 @@
+/*
+ * File:   KrakenIntegrationTest.cpp
+ * Author: Kjell Hedstrom
+ *
+ * Created on February 9, 2015
+ */
+
+
+#include "KrakenIntegrationTest.h"
+#include "Kraken.h"
+#include "KrakenBattle.h"
+#include "Harpoon.h"
+#include <memory>
+#include <atomic>
+#include <thread>
+#include <future>
+#include <StopWatch.h>
+#include <cstdlib>
+
+namespace {
+   Kraken::Chunks GetRandomData(const size_t sizeOfData) {
+      Kraken::Chunks someData;
+      for (size_t j = 0; j < sizeOfData; j++) {
+         someData.push_back(rand() % 255);
+      }
+      return someData;
+   }
+
+
+   std::string vectorToString(const std::vector<uint8_t>& vec) {
+      std::string data;
+      std::copy(vec.begin(), vec.end(), std::back_inserter(data));
+      return data;
+   }
+
+   std::string vectorToString(const std::vector<uint8_t>& vec, size_t stopper) {
+      std::string data;
+      stopper = std::min(stopper, vec.size());
+      std::copy(vec.begin(), vec.begin() + stopper, std::back_inserter(data));
+      return data;
+   }
+
+} // anonymous
+
+
+
+
+// This integration test is imporant also since it's the only one that truly tests
+// the KrakenBattle::SendChunks (cpp hidden file)
+//
+// To verify the expected steps in this communication
+// 0. some header (in this case just 'hello')
+// 1. uuid<DATA>w,o,r,l,d
+// 2. uuid<DATA> - part1 10MB
+// 3. uuid<DATA> - part2 10MB
+// 4. uuid<DONE>
+// 5. uuid<END>
+TEST_F(KrakenIntegrationTest, VerifyCommunication) {
+   using namespace KrakenBattle;
+
+   Kraken::Chunks header = {'h', 'e', 'l', 'l', 'o'};
+
+// 10MB
+   const size_t kMaxChunkSize_10MB = 10 * 1024 * 1024;
+   const std::string session = "some-random-session";
+   const auto chunk1 = Kraken::Chunks{'w', 'o', 'r', 'l', 'd'};
+   const auto chunk2 = GetRandomData(kMaxChunkSize_10MB);
+
+
+
+   const std::string queue = "tcp://127.0.0.1:15123";
+   Kraken kraken;
+   kraken.MaxWaitInMs(1000);
+   auto spear = kraken.SetLocation(queue);
+   EXPECT_EQ(spear, Kraken::Spear::IMPALED) << "spear: " << static_cast<int>(spear);
+
+   size_t tooHighValue = 100;
+   std::shared_ptr<std::atomic<size_t>> allReceived {new std::atomic<size_t>{tooHighValue}};
+   std::shared_ptr<Harpoon> harpoon = std::make_shared<Harpoon>();
+   harpoon->Aim(queue);
+   harpoon->MaxWaitInMs(1000);
+
+   // RECEIVER
+   using HarpoonReceived = std::vector<Kraken::Chunks>;
+   std::future<HarpoonReceived> willReceive = std::async(std::launch::async,  [allReceived, harpoon] {
+      StopWatch stopWatch;
+      HarpoonReceived data;
+      while (allReceived->load() != data.size() && stopWatch.ElapsedSec() < 10) {
+         Kraken::Chunks blood;
+         harpoon->Heave(blood);
+         if (blood.size() > 0) {
+            data.push_back(blood);
+         }
+      }
+      return data;
+   });
+
+
+
+   // SENDER
+   // send all stuff - happy path
+   const std::string noError = {"no error"};
+   // send header
+   auto status = KrakenBattle::ForwardChunksToClient(&kraken, session, header, SendType::Data, noError);
+   EXPECT_EQ(status, KrakenBattle::ProgressType::Continue) << "received: " << KrakenBattle::EnumToString(status);
+
+   // send data1: world
+   status = KrakenBattle::ForwardChunksToClient(&kraken, session, chunk1, SendType::Data, noError);
+   EXPECT_EQ(status, KrakenBattle::ProgressType::Continue)<< "received: " << KrakenBattle::EnumToString(status);
+
+   // send data2: 10MB - which will be split up multiple times
+   status = KrakenBattle::ForwardChunksToClient(&kraken, session, chunk2, SendType::Data, noError);
+   EXPECT_EQ(status, KrakenBattle::ProgressType::Continue)<< "received: " << KrakenBattle::EnumToString(status);
+
+   // send data3: done
+   const Kraken::Chunks noChunk = {};
+   status = KrakenBattle::ForwardChunksToClient(&kraken, session, noChunk, SendType::Done, noError);
+   EXPECT_EQ(status, KrakenBattle::ProgressType::Continue) << "received: " << KrakenBattle::EnumToString(status);
+   // send data4: end
+   status = KrakenBattle::ForwardChunksToClient(&kraken, session, noChunk, SendType::End, noError);
+   EXPECT_EQ(status, KrakenBattle::ProgressType::Continue) << "received: " << KrakenBattle::EnumToString(status);
+
+
+   
+
+   // VERIFY
+   // expected
+   // 0. header: hello
+   // 1. uuid<DATA>world
+   // 2. uuid<DATA> - part1 10MB
+   // 3. uuid<DATA> - part2 10MB
+   // 4. uuid<DONE>
+   // 5. uuid<END>
+   const size_t kExpectedNumberOfSendActions = 6;
+   allReceived->store(kExpectedNumberOfSendActions); // signal the async job to exit before the timer
+   const auto kReceived = willReceive.get();
+   const auto kChunkHeader = header;
+   const auto kExpectedHeader = MergeData(session, SendType::Data, kChunkHeader, noError);
+   const auto kSessionHeader = MergeData(session, SendType::Data, {}, {});
+   auto chunk1Expected = MergeData(session, SendType::Data, chunk1, noError);
+
+   ASSERT_EQ(kReceived.size(), kExpectedNumberOfSendActions);
+   auto vec = kReceived[0];
+   EXPECT_TRUE((kExpectedHeader == vec)) << vectorToString(vec);
+
+   vec = kReceived[1];
+   EXPECT_TRUE((chunk1Expected == vec)) << vectorToString(vec);
+
+   vec = kReceived[2];
+   Kraken::Chunks chunk2_part1 = {};
+   chunk2_part1.reserve(kMaxChunkSize_10MB);
+   std::copy(kSessionHeader.begin(), kSessionHeader.end(), std::back_inserter(chunk2_part1));
+   std::copy(chunk2.begin(), chunk2.begin() + kMaxChunkSize_10MB - kSessionHeader.size(),
+             std::back_inserter(chunk2_part1));
+   EXPECT_EQ(chunk2_part1.size(), kMaxChunkSize_10MB);
+   EXPECT_TRUE((chunk2_part1 == vec)) << "vec50 = " << vectorToString(vec, 50) << "\n\nchunk2_part1_50 = " << vectorToString(chunk2_part1, 50);
+
+
+   vec = kReceived[3];
+   Kraken::Chunks chunk2_part2 = {};
+   chunk2_part2.reserve(kMaxChunkSize_10MB);
+   std::copy(kSessionHeader.begin(), kSessionHeader.end(), std::back_inserter(chunk2_part2));
+   std::copy(chunk2.begin() + (kMaxChunkSize_10MB - kSessionHeader.size()), chunk2.end(), std::back_inserter(chunk2_part2));
+   EXPECT_TRUE(chunk2_part2.size() < kMaxChunkSize_10MB) << "chunkSize: " << chunk2_part2.size();
+   EXPECT_TRUE((chunk2_part2 == vec)) << "vec50 = " << vectorToString(vec, 50) << "\n\nchunk2_part2_50 = " << vectorToString(chunk2_part2, 50);
+
+
+   vec = kReceived[4];
+   auto doneExpected = MergeData(session, SendType::Done, noChunk, noError);
+   EXPECT_TRUE((doneExpected == vec)) << vectorToString(vec);
+
+   vec = kReceived[5];
+   auto endExpected = MergeData(session, SendType::End, noChunk, noError);
+   EXPECT_TRUE((endExpected == vec)) << vectorToString(vec);
+   
+}
+
+

--- a/test/KrakenIntegrationTest.h
+++ b/test/KrakenIntegrationTest.h
@@ -1,0 +1,36 @@
+/*
+ * File:   KrakenIntegrationTest.h
+ * Author: Kjell Hedstrom
+ *
+ * Created on November 24, 2015
+ */
+
+#pragma once
+
+#include <gtest/gtest.h>
+#include <string>
+#include <cstdlib>
+
+class KrakenIntegrationTest : public ::testing::Test {
+public:
+   KrakenIntegrationTest() :
+      mTestDirectory("/tmp/TestOfKrakenIntegrationTest"),
+      mCreateTestDirectory("mkdir -p " + mTestDirectory),
+      mTearDownTestDirectory("rm -rf " + mTestDirectory) {}
+
+   virtual ~KrakenIntegrationTest() = default;
+
+protected:
+   virtual void SetUp() {
+      system(mTearDownTestDirectory.c_str());
+      EXPECT_EQ(0, system(mCreateTestDirectory.c_str()));
+   }
+
+   virtual void TearDown() {
+      EXPECT_EQ(0, system(mTearDownTestDirectory.c_str()));
+   }
+
+   std::string mTestDirectory;
+   std::string mCreateTestDirectory;
+   std::string mTearDownTestDirectory;
+};


### PR DESCRIPTION
Initial commit for the refactoring when moving over chunk sending fo kraken from Research to Queuenado.

The actual sending test is still in Research.   I  will have a separate pull request for that one later. 